### PR TITLE
Add countDocs method

### DIFF
--- a/src/DocumentStore.php
+++ b/src/DocumentStore.php
@@ -143,4 +143,12 @@ interface DocumentStore
      * @return array
      */
     public function filterDocIds(string $collectionName, Filter $filter): array;
+
+    /**
+     * @param string $collectionName
+     * @param Filter $filter
+     * @return int The number of documents
+     * @throws UnknownCollection
+     */
+    public function countDocs(string $collectionName, Filter $filter): int;
 }

--- a/src/InMemoryDocumentStore.php
+++ b/src/InMemoryDocumentStore.php
@@ -572,4 +572,21 @@ final class InMemoryDocumentStore implements DocumentStore
 
         return \array_keys($array) === \range(0, \count($array) - 1);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function countDocs(string $collectionName, Filter $filter) : int
+    {
+        $this->assertHasCollection($collectionName);
+
+        $counter = 0;
+        foreach ($this->inMemoryConnection['documents'][$collectionName] as $docId => $doc) {
+            if ($filter->match($doc, $docId)) {
+                $counter++;
+            }
+        }
+
+        return $counter;
+    }
 }


### PR DESCRIPTION
This allows one to get the number of affected documents without actually
having to retrieve all the documents from the store.

This fixes https://github.com/event-engine/php-document-store/issues/1