### PR TITLE
fix: Mimic how postgres-document-store works, where documents are not merged recursively.

### DIFF
--- a/src/InMemoryDocumentStore.php
+++ b/src/InMemoryDocumentStore.php
@@ -205,7 +205,7 @@ final class InMemoryDocumentStore implements DocumentStore
         $this->assertDocExists($collectionName, $docId);
         $this->assertUniqueConstraints($collectionName, $docId, $docOrSubset);
 
-        $this->inMemoryConnection['documents'][$collectionName][$docId] = $this->arrayReplaceRecursiveAssocOnly(
+        $this->inMemoryConnection['documents'][$collectionName][$docId] = $this->arrayReplace(
             $this->inMemoryConnection['documents'][$collectionName][$docId],
             $docOrSubset
         );
@@ -550,7 +550,7 @@ final class InMemoryDocumentStore implements DocumentStore
 
         if($this->hasDoc($collectionName, $docId)) {
             $effectedDoc = $this->getDoc($collectionName, $docId);
-            $docOrSubset = $this->arrayReplaceRecursiveAssocOnly($effectedDoc, $docOrSubset);
+            $docOrSubset = $this->arrayReplace($effectedDoc, $docOrSubset);
         }
 
         $reader = new ArrayReader($docOrSubset);
@@ -672,30 +672,13 @@ final class InMemoryDocumentStore implements DocumentStore
      * @param array $array2
      * @return array
      */
-    private function arrayReplaceRecursiveAssocOnly(array $array1, array $array2): array
+    private function arrayReplace(array $array1, array $array2): array
     {
         foreach ($array2 as $key2 => $value2) {
-            $bothValuesArraysAndAtLeastOneAssoc = \is_array($value2) &&
-                isset($array1[$key2]) && \is_array($array1[$key2]) &&
-                !($this->isSequentialArray($value2) && $this->isSequentialArray($array1[$key2]));
-
-            if ($bothValuesArraysAndAtLeastOneAssoc) {
-                $array1[$key2] = $this->arrayReplaceRecursiveAssocOnly($array1[$key2], $value2);
-            } else {
-                $array1[$key2] = $value2;
-            }
+            $array1[$key2] = $value2;
         }
 
         return $array1;
-    }
-
-    private function isSequentialArray(array $array): bool
-    {
-        if (\count($array) === 0) {
-            return true;
-        }
-
-        return \array_keys($array) === \range(0, \count($array) - 1);
     }
 
     private function transformToPartialDoc(array $doc, PartialSelect $partialSelect): array

--- a/tests/InMemoryDocumentStoreTest.php
+++ b/tests/InMemoryDocumentStoreTest.php
@@ -92,9 +92,7 @@ final class InMemoryDocumentStoreTest extends TestCase
         $doc = [
             'some' => [
                 'prop' => 'foo',
-                'other' => [
-                    'nested' => 42
-                ]
+                'other' => 'bar',
             ],
             'baz' => 'bat',
         ];
@@ -108,7 +106,7 @@ final class InMemoryDocumentStoreTest extends TestCase
         ]);
 
         $filteredDocs = array_values(iterator_to_array($this->store->findDocs('test', new EqFilter('some.prop', 'fuzz'))));
-        $this->assertEquals(42, $filteredDocs[0]['some']['other']['nested']);
+        $this->assertArrayNotHasKey('other', $filteredDocs[0]['some']);
     }
 
     /**
@@ -424,6 +422,7 @@ final class InMemoryDocumentStoreTest extends TestCase
 
         $this->store->addDoc('test', '1', ['some' => ['prop' => 'foo', 'other' => ['prop' => 'bat']]]);
         $this->store->addDoc('test', '2', ['some' => ['prop' => 'bar', 'other' => ['prop' => 'bat']]]);
+        $this->store->addDoc('test', '3', ['some' => ['prop' => 'bar']]);
 
         $this->expectExceptionMessageRegExp('/^Unique constraint violation/');
         $this->store->addDoc('test', '4', ['some' => ['prop' => 'foo', 'other' => ['prop' => 'bat']]]);
@@ -443,7 +442,7 @@ final class InMemoryDocumentStoreTest extends TestCase
         $this->store->addDoc('test', '3', ['some' => ['prop' => 'bar']]);
 
         $this->expectExceptionMessageRegExp('/^Unique constraint violation/');
-        $this->store->updateDoc('test', '2', ['some' => ['prop' => 'foo']]);
+        $this->store->updateDoc('test', '2', ['some' => ['prop' => 'foo', 'other' => ['prop' => 'bat']]]);
     }
 
     /**
@@ -574,7 +573,7 @@ final class InMemoryDocumentStoreTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_update_numeric_arrays_recursively()
+    public function it_does_not_update_arrays_recursively()
     {
         $this->store->addCollection('test');
 
@@ -604,13 +603,13 @@ final class InMemoryDocumentStoreTest extends TestCase
 
         $this->assertEquals(
             [
-                'a' => ['a' => 10, 'b' => 21, 'c' => 30],
+                'a' => ['b' => 21, 'c' => 30],
                 'b' => [10, 30],
                 'c' => [true],
                 'd' => [],
-                'e' => ['a' => 'b'],
-                'f' => [10, 20, 'x' => 10, 'y' => 20],
-                'g' => ['x' => 10, 'y' => 20, 30, 40],
+                'e' => [],
+                'f' => ['x' => 10, 'y' => 20],
+                'g' => [30, 40],
                 'h' => [11],
                 'i' => [22],
                 'j' => ['bar']


### PR DESCRIPTION
If merged, this would make `InMemoryDocumentStore` behave like `PostgresDocumentStore` during document updates, whereby, the documents (the old and the new) associative arrays are not merged recursively.

See: https://github.com/event-engine/php-document-store/issues/17