### PR TITLE
feature: add replaceDoc and replaceMany methods to prevent merge

### DIFF
--- a/src/DocumentStore.php
+++ b/src/DocumentStore.php
@@ -105,6 +105,24 @@ interface DocumentStore
     /**
      * @param string $collectionName
      * @param string $docId
+     * @param array $doc
+     * @throws UnknownCollection
+     * @throws RuntimeException if updating did not succeed
+     */
+    public function replaceDoc(string $collectionName, string $docId, array $doc): void;
+
+    /**
+     * @param string $collectionName
+     * @param Filter $filter
+     * @param array $set
+     * @throws UnknownCollection
+     * @throws RuntimeException in case of connection error or other issues
+     */
+    public function replaceMany(string $collectionName, Filter $filter, array $set): void;
+
+    /**
+     * @param string $collectionName
+     * @param string $docId
      * @throws UnknownCollection
      * @throws RuntimeException if deleting did not succeed
      */

--- a/src/InMemoryDocumentStore.php
+++ b/src/InMemoryDocumentStore.php
@@ -250,6 +250,39 @@ final class InMemoryDocumentStore implements DocumentStore
     /**
      * @param string $collectionName
      * @param string $docId
+     * @param array  $doc
+     * @throws \THrowable if replacing did not succeed
+     */
+    public function replaceDoc(string $collectionName, string $docId, array $doc): void
+    {
+        $this->assertDocExists($collectionName, $docId);
+        $this->assertUniqueConstraints($collectionName, $docId, $doc);
+
+        $this->inMemoryConnection['documents'][$collectionName][$docId] = $doc;
+    }
+
+    /**
+     * @param string $collectionName
+     * @param Filter $filter
+     * @param array $set
+     * @throws \Throwable in case of connection error or other issues
+     */
+    public function replaceMany(string $collectionName, Filter $filter, array $set): void
+    {
+        $this->assertHasCollection($collectionName);
+
+        $docs = $this->inMemoryConnection['documents'][$collectionName];
+
+        foreach ($docs as $docId => $doc) {
+            if ($filter->match($doc, (string)$docId)) {
+                $this->replaceDoc($collectionName, (string)$docId, $set);
+            }
+        }
+    }
+
+    /**
+     * @param string $collectionName
+     * @param string $docId
      * @throws \Throwable if deleting did not succeed
      */
     public function deleteDoc(string $collectionName, string $docId): void

--- a/tests/InMemoryDocumentStoreTest.php
+++ b/tests/InMemoryDocumentStoreTest.php
@@ -114,6 +114,36 @@ final class InMemoryDocumentStoreTest extends TestCase
     /**
      * @test
      */
+    public function it_replaces_a_doc()
+    {
+        $this->store->addCollection('test');
+
+        $doc = [
+            'some' => [
+                'prop' => 'foo',
+                'other' => [
+                    'nested' => 42
+                ]
+            ],
+            'baz' => 'bat',
+        ];
+
+        $this->store->addDoc('test', '1', $doc);
+
+        $doc = ['baz' => 'changed val'];
+
+        $this->store->replaceDoc('test', '1', $doc);
+
+        $filter = new EqFilter('baz', 'changed val');
+
+        $filteredDocs = $this->store->findDocs('test', $filter);
+
+        $this->assertCount(1, $filteredDocs);
+    }
+
+    /**
+     * @test
+     */
     public function it_retrieves_doc_ids_by_filter()
     {
         $this->store->addCollection('test');
@@ -547,6 +577,30 @@ final class InMemoryDocumentStoreTest extends TestCase
         $this->assertCount(2, $filteredDocs);
         $this->assertEquals('fuzz', $filteredDocs[0]['some']['prop']);
         $this->assertEquals('fuzz', $filteredDocs[1]['some']['prop']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_replaces_many()
+    {
+        $this->store->addCollection('test');
+
+        $this->store->addDoc('test', '1', ['some' => ['prop' => 'foo', 'other' => ['prop' => 'bat']]]);
+        $this->store->addDoc('test', '2', ['some' => ['prop' => 'bar', 'other' => ['prop' => 'bat']]]);
+        $this->store->addDoc('test', '3', ['some' => ['prop' => 'bar']]);
+
+        $this->store->replaceMany(
+            'test',
+            new EqFilter('some.other.prop', 'bat'),
+            ['some' => ['prop' => 'fuzz']]
+        );
+
+        $filteredDocs = array_values(iterator_to_array($this->store->findDocs('test', new EqFilter('some.prop', 'fuzz'))));
+
+        $this->assertCount(2, $filteredDocs);
+        $this->assertEquals(['some' => ['prop' => 'fuzz']], $filteredDocs[0]);
+        $this->assertEquals(['some' => ['prop' => 'fuzz']], $filteredDocs[1]);
     }
 
     /**


### PR DESCRIPTION
This allows for documents to be replaced out right instead of merging with an existing document. For example, if the keys are dynamically generated, and needs to be removed from a new document, this would allow a way to do that.

Note that by adding the methods to the interface, this would pose a BC break upstream. This is addressed in PR: https://github.com/event-engine/php-postgres-document-store/pull/16.

Relates to https://github.com/event-engine/php-document-store/issues/17.